### PR TITLE
feat: add cg-inject binary for Pumba --inject-cgroup mode

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build:
+    name: Build (${{ matrix.platform }})
     strategy:
       matrix:
         include:
@@ -22,6 +23,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run unit tests
+        run: go test -race ./cmd/cg-inject/
 
       - name: Install build dependencies
         run: |
@@ -72,6 +82,7 @@ jobs:
           retention-days: 1
 
   merge:
+    name: Merge Manifests
     runs-on: ubuntu-24.04
     needs: build
     outputs:
@@ -112,6 +123,7 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
   test:
+    name: Integration Tests
     runs-on: ubuntu-24.04
     needs: merge
     steps:
@@ -123,18 +135,13 @@ jobs:
           TEST_IMAGE="ghcr.io/${{ github.repository_owner }}/stress-ng:${{ needs.merge.outputs.version }}" ./tests/test-docker.sh
 
   github-release:
+    name: GitHub Release
     runs-on: ubuntu-24.04
     needs: [merge, test]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Get previous tag
-        id: prev_tag
-        run: |
-          prev=$(git tag --sort=-v:refname | sed -n '2p' || echo "")
-          echo "prev_tag=${prev}" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
         run: |
@@ -144,13 +151,19 @@ jobs:
           {
             echo "## stress-ng ${version}"
             echo ""
-            echo "Minimal \`scratch\` Docker image with statically linked [stress-ng ${version}](https://github.com/ColinIanKing/stress-ng/tree/V${version})."
+            echo "Minimal \`scratch\` Docker image with statically linked [stress-ng ${version}](https://github.com/ColinIanKing/stress-ng/tree/V${version}) and [\`cg-inject\`](./cmd/cg-inject/) helper binary."
             echo ""
             echo "### Docker Image"
             echo ""
             echo "\`\`\`bash"
             echo "docker pull ghcr.io/alexei-led/stress-ng:${version}"
             echo "\`\`\`"
+            echo ""
+            echo "### Binaries"
+            echo "| Binary | Purpose |"
+            echo "|--------|---------|"
+            echo "| \`/stress-ng\` | Default entrypoint — the stress-ng tool |"
+            echo "| \`/cg-inject\` | Pumba \`--inject-cgroup\` helper — joins cgroup then exec's stress-ng |"
             echo ""
             echo "### Platforms"
             echo "- \`linux/amd64\` (native runner)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,9 +27,50 @@ jobs:
           scandir: .
           severity: warning
 
-  build-and-test:
+  go-lint:
+    name: Go Lint
     runs-on: ubuntu-latest
-    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+          args: --timeout=3m
+
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run unit tests
+        run: go test -v -race -coverprofile=coverage.out ./cmd/cg-inject/
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: cg-inject
+        continue-on-error: true
+
+  build-and-test:
+    name: Build & Integration Test
+    runs-on: ubuntu-latest
+    needs: [lint, go-lint, go-test]
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-stress-ng
+# compiled binaries at repo root
+/stress-ng
+/cg-inject
+
+# test coverage
+coverage.out

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,78 @@
+version: "2"
+
+run:
+  timeout: 3m
+
+linters:
+  default: none
+  enable:
+    - asciicheck
+    - bidichk
+    - durationcheck
+    - errcheck
+    - errorlint
+    - funlen
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gosec
+    - govet
+    - ineffassign
+    - maintidx
+    - misspell
+    - nakedret
+    - nilerr
+    - nolintlint
+    - predeclared
+    - reassign
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+  settings:
+    funlen:
+      lines: 80
+      statements: 40
+    gocyclo:
+      min-complexity: 15
+    gocognit:
+      min-complexity: 20
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    misspell:
+      locale: US
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+      disabled-checks:
+        - ifElseChain
+        - unnamedResult
+        - whyNoLint
+    gosec:
+      excludes:
+        - G204 # subprocess launched with variable — intentional in cg-inject (exec)
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - funlen
+          - gosec
+          - gocognit
+          - goconst
+          - gocyclo
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,6 +71,7 @@ linters:
           - gocognit
           - goconst
           - gocyclo
+          - maintidx
 
 formatters:
   enable:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build cg-inject ─────────────────────────────────────────────────
+# cg-inject is a pure-stdlib Go binary that joins a target container's cgroup
+# before exec-ing stress-ng, enabling same-cgroup stress testing (Pumba's
+# --inject-cgroup mode). CGO disabled; result is a fully static binary.
+FROM golang:1.23-alpine AS cg-inject-builder
+WORKDIR /src
+COPY go.mod ./
+COPY cmd/cg-inject/ ./cmd/cg-inject/
+RUN CGO_ENABLED=0 GOOS=linux go build \
+        -ldflags="-s -w" \
+        -trimpath \
+        -o /cg-inject \
+        ./cmd/cg-inject/
+
+# ── Stage 2: final scratch image ─────────────────────────────────────────────
+# stress-ng is compiled on the CI runner (native, with all build deps) and
+# copied in at build time via --build-context or plain COPY.
+# cg-inject is copied from the builder stage above.
 FROM scratch
+COPY --from=cg-inject-builder /cg-inject /cg-inject
+# hadolint ignore=DL3010
 COPY stress-ng /stress-ng
+# Default entrypoint is stress-ng for direct use.
+# Pumba's --inject-cgroup mode overrides ENTRYPOINT to /cg-inject.
 ENTRYPOINT ["/stress-ng"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: test lint fmt build clean help
+
+BINARY       := cg-inject
+MODULE       := ./cmd/cg-inject/
+GOFLAGS      := CGO_ENABLED=0
+BUILD_FLAGS  := -ldflags="-s -w" -trimpath
+
+## help: Show this help message
+help:
+	@grep -E '^##' $(MAKEFILE_LIST) | sed 's/## //'
+
+## test: Run unit tests with race detector
+test:
+	go test -v -race -coverprofile=coverage.out $(MODULE)
+	@go tool cover -func=coverage.out | tail -1
+
+## lint: Run golangci-lint
+lint:
+	golangci-lint run --timeout=3m ./...
+
+## fmt: Format Go code
+fmt:
+	gofmt -w -s .
+	goimports -w .
+
+## build: Build cg-inject binary (Linux static)
+build:
+	$(GOFLAGS) go build $(BUILD_FLAGS) -o $(BINARY) $(MODULE)
+
+## clean: Remove build artifacts
+clean:
+	rm -f $(BINARY) coverage.out

--- a/cmd/cg-inject/main.go
+++ b/cmd/cg-inject/main.go
@@ -1,0 +1,277 @@
+// cg-inject is a minimal binary that moves itself into a target container's cgroup
+// and then exec's stress-ng (or any other command). This enables same-cgroup stress
+// testing where stress-ng shares resource accounting with the target container.
+//
+// Usage:
+//
+//	cg-inject --target-id <containerID> [--cgroup-driver auto|cgroupfs|systemd] -- /stress-ng <args...>
+//	cg-inject --cgroup-path <path> -- /stress-ng <args...>
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// cgroupVersion represents the cgroup hierarchy version.
+type cgroupVersion int
+
+const (
+	cgroupV1 cgroupVersion = 1
+	cgroupV2 cgroupVersion = 2
+)
+
+// cgroupDriver represents the Docker cgroup driver.
+type cgroupDriver string
+
+const (
+	driverAuto     cgroupDriver = "auto"
+	driverCgroupfs cgroupDriver = "cgroupfs"
+	driverSystemd  cgroupDriver = "systemd"
+)
+
+// config holds the parsed command-line configuration.
+type config struct {
+	targetID    string
+	cgroupPath  string // explicit cgroup base path (e.g., /kubepods/burstable/pod-uid/container-id)
+	driver      cgroupDriver
+	commandArgs []string
+}
+
+// for testing: override cgroup filesystem root and syscall.Exec
+var (
+	cgroupRoot  = "/sys/fs/cgroup"
+	execCommand = syscall.Exec
+)
+
+func main() {
+	cfg, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cg-inject: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "cg-inject: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseArgs(args []string) (config, error) {
+	cfg := config{driver: driverAuto}
+
+	// find the -- separator
+	dashIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			dashIdx = i
+			break
+		}
+	}
+	if dashIdx < 0 {
+		return cfg, errors.New("missing '--' separator before command")
+	}
+
+	cfg.commandArgs = args[dashIdx+1:]
+	if len(cfg.commandArgs) == 0 {
+		return cfg, errors.New("no command specified after '--'")
+	}
+
+	if err := parseFlags(&cfg, args[:dashIdx]); err != nil {
+		return cfg, err
+	}
+	if err := validateConfig(&cfg); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}
+
+func parseFlags(cfg *config, flagArgs []string) error {
+	for i := 0; i < len(flagArgs); i++ {
+		switch flagArgs[i] {
+		case "--target-id":
+			i++
+			if i >= len(flagArgs) {
+				return errors.New("--target-id requires a value")
+			}
+			cfg.targetID = flagArgs[i]
+		case "--cgroup-driver":
+			i++
+			if i >= len(flagArgs) {
+				return errors.New("--cgroup-driver requires a value")
+			}
+			d := cgroupDriver(flagArgs[i])
+			if d != driverAuto && d != driverCgroupfs && d != driverSystemd {
+				return fmt.Errorf("unknown cgroup driver %q (expected auto, cgroupfs, or systemd)", flagArgs[i])
+			}
+			cfg.driver = d
+		case "--cgroup-path":
+			i++
+			if i >= len(flagArgs) {
+				return errors.New("--cgroup-path requires a value")
+			}
+			cfg.cgroupPath = flagArgs[i]
+		default:
+			return fmt.Errorf("unknown flag %q", flagArgs[i])
+		}
+	}
+	return nil
+}
+
+func validateConfig(cfg *config) error {
+	if cfg.cgroupPath != "" {
+		if cfg.targetID != "" {
+			return errors.New("--cgroup-path and --target-id are mutually exclusive")
+		}
+		if strings.Contains(cfg.cgroupPath, "..") {
+			return errors.New("--cgroup-path must not contain '..' path components")
+		}
+		return nil
+	}
+	if cfg.targetID == "" {
+		return errors.New("--target-id is required (or use --cgroup-path)")
+	}
+	if !isValidContainerID(cfg.targetID) {
+		return fmt.Errorf("invalid container ID %q: must be 12-64 hex characters", cfg.targetID)
+	}
+	return nil
+}
+
+const (
+	minContainerIDLen = 12
+	maxContainerIDLen = 64
+)
+
+// isValidContainerID checks that the string is a valid Docker container ID (12-64 hex chars).
+func isValidContainerID(id string) bool {
+	if len(id) < minContainerIDLen || len(id) > maxContainerIDLen {
+		return false
+	}
+	for _, c := range id {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func run(cfg config) error {
+	version := detectCgroupVersion()
+
+	var paths []string
+	if cfg.cgroupPath != "" {
+		paths = cgroupProcsPathsFromBase(cfg.cgroupPath, version)
+	} else {
+		driver := cfg.driver
+		if driver == driverAuto {
+			driver = detectDriver(version)
+		}
+		paths = cgroupProcsPaths(cfg.targetID, version, driver)
+	}
+
+	pid := os.Getpid()
+	for _, procsPath := range paths {
+		if err := writePID(procsPath, pid); err != nil {
+			return fmt.Errorf("writing PID %d to %s: %w", pid, procsPath, err)
+		}
+	}
+
+	// Resolve the full path to the command
+	cmdPath := cfg.commandArgs[0]
+	return execCommand(cmdPath, cfg.commandArgs, os.Environ())
+}
+
+// detectCgroupVersion checks whether the system uses cgroups v2 or v1.
+// If /sys/fs/cgroup/cgroup.controllers exists, it's v2.
+func detectCgroupVersion() cgroupVersion {
+	if _, err := os.Stat(cgroupRoot + "/cgroup.controllers"); err == nil {
+		return cgroupV2
+	}
+	return cgroupV1
+}
+
+// detectDriver infers the Docker cgroup driver by looking for Docker-specific
+// cgroup directories. The /docker/ directory is created by the cgroupfs driver,
+// while docker-*.scope entries under system.slice are created by the systemd driver.
+// Falls back to cgroupfs (Docker's default) if neither is found.
+func detectDriver(version cgroupVersion) cgroupDriver {
+	if version == cgroupV2 {
+		// Check for cgroupfs driver's /docker/ directory first (Docker's default)
+		if _, err := os.Stat(cgroupRoot + "/docker"); err == nil {
+			return driverCgroupfs
+		}
+		// Check for systemd driver's scope entries
+		if _, err := os.Stat(cgroupRoot + "/system.slice"); err == nil {
+			return driverSystemd
+		}
+	} else {
+		// v1: check under the cpu controller hierarchy
+		if _, err := os.Stat(cgroupRoot + "/cpu/docker"); err == nil {
+			return driverCgroupfs
+		}
+		if _, err := os.Stat(cgroupRoot + "/cpu/system.slice"); err == nil {
+			return driverSystemd
+		}
+	}
+	return driverCgroupfs
+}
+
+// v1Controllers lists the cgroup v1 controller hierarchies that stress-ng needs
+// for accurate resource accounting (CPU, memory, block I/O, CPU accounting, PIDs).
+var v1Controllers = []string{"cpu", "memory", "blkio", "cpuacct", "pids"}
+
+// cgroupProcsPaths returns the cgroup.procs paths to write the PID into.
+// On cgroups v2 (unified hierarchy), a single write covers all controllers.
+// On cgroups v1, each controller has a separate hierarchy requiring its own write.
+func cgroupProcsPaths(targetID string, version cgroupVersion, driver cgroupDriver) []string {
+	if version == cgroupV2 {
+		if driver == driverSystemd {
+			return []string{cgroupRoot + "/system.slice/docker-" + targetID + ".scope/cgroup.procs"}
+		}
+		return []string{cgroupRoot + "/docker/" + targetID + "/cgroup.procs"}
+	}
+	// cgroups v1: write to each controller hierarchy
+	paths := make([]string, 0, len(v1Controllers))
+	for _, ctrl := range v1Controllers {
+		if driver == driverSystemd {
+			paths = append(paths, cgroupRoot+"/"+ctrl+"/system.slice/docker-"+targetID+".scope/cgroup.procs")
+		} else {
+			paths = append(paths, cgroupRoot+"/"+ctrl+"/docker/"+targetID+"/cgroup.procs")
+		}
+	}
+	return paths
+}
+
+// cgroupProcsPathsFromBase returns cgroup.procs paths using an explicit base cgroup path.
+// On cgroups v2, a single path suffices. On v1, each controller hierarchy is addressed.
+// path.Join is used to normalize double slashes when basePath has a leading slash.
+func cgroupProcsPathsFromBase(basePath string, version cgroupVersion) []string {
+	if version == cgroupV2 {
+		return []string{path.Join(cgroupRoot, basePath, "cgroup.procs")}
+	}
+	paths := make([]string, 0, len(v1Controllers))
+	for _, ctrl := range v1Controllers {
+		paths = append(paths, path.Join(cgroupRoot, ctrl, basePath, "cgroup.procs"))
+	}
+	return paths
+}
+
+// writePID writes a PID to an existing cgroup.procs file.
+// Uses O_WRONLY without O_CREATE to fail if the cgroup path doesn't exist.
+func writePID(procsPath string, pid int) error {
+	f, err := os.OpenFile(filepath.Clean(procsPath), os.O_WRONLY, 0) //#nosec G703 -- procsPath is constructed internally, not user input
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(f, "%d\n", pid)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}

--- a/cmd/cg-inject/main_test.go
+++ b/cmd/cg-inject/main_test.go
@@ -1,0 +1,634 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    config
+		wantErr string
+	}{
+		{
+			name: "basic with defaults",
+			args: []string{"--target-id", "aabbccddeeff", "--", "/stress-ng", "--cpu", "1"},
+			want: config{
+				targetID:    "aabbccddeeff",
+				driver:      driverAuto,
+				commandArgs: []string{"/stress-ng", "--cpu", "1"},
+			},
+		},
+		{
+			name: "explicit cgroupfs driver",
+			args: []string{"--target-id", "aabbccddeeff", "--cgroup-driver", "cgroupfs", "--", "/stress-ng"},
+			want: config{
+				targetID:    "aabbccddeeff",
+				driver:      driverCgroupfs,
+				commandArgs: []string{"/stress-ng"},
+			},
+		},
+		{
+			name: "explicit systemd driver",
+			args: []string{"--target-id", "ddeeff112233", "--cgroup-driver", "systemd", "--", "/stress-ng", "-v"},
+			want: config{
+				targetID:    "ddeeff112233",
+				driver:      driverSystemd,
+				commandArgs: []string{"/stress-ng", "-v"},
+			},
+		},
+		{
+			name: "auto driver explicit",
+			args: []string{"--cgroup-driver", "auto", "--target-id", "112233aabbcc", "--", "/bin/sh"},
+			want: config{
+				targetID:    "112233aabbcc",
+				driver:      driverAuto,
+				commandArgs: []string{"/bin/sh"},
+			},
+		},
+		{
+			name:    "missing separator",
+			args:    []string{"--target-id", "aabbccddeeff"},
+			wantErr: "missing '--' separator before command",
+		},
+		{
+			name:    "no command after separator",
+			args:    []string{"--target-id", "aabbccddeeff", "--"},
+			wantErr: "no command specified after '--'",
+		},
+		{
+			name:    "invalid container ID",
+			args:    []string{"--target-id", "not-a-hex-id", "--", "/stress-ng"},
+			wantErr: "invalid container ID",
+		},
+		{
+			name:    "container ID too short",
+			args:    []string{"--target-id", "abc12", "--", "/stress-ng"},
+			wantErr: "invalid container ID",
+		},
+		{
+			name:    "missing target-id",
+			args:    []string{"--", "/stress-ng"},
+			wantErr: "--target-id is required",
+		},
+		{
+			name:    "target-id without value",
+			args:    []string{"--target-id", "--", "/stress-ng"},
+			wantErr: "--target-id requires a value",
+		},
+		{
+			name:    "cgroup-driver without value",
+			args:    []string{"--target-id", "abc", "--cgroup-driver", "--", "/stress-ng"},
+			wantErr: "--cgroup-driver requires a value",
+		},
+		{
+			name:    "unknown cgroup driver",
+			args:    []string{"--target-id", "abc", "--cgroup-driver", "nope", "--", "/stress-ng"},
+			wantErr: `unknown cgroup driver "nope"`,
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{"--target-id", "abc", "--bogus", "--", "/stress-ng"},
+			wantErr: `unknown flag "--bogus"`,
+		},
+		{
+			name: "cgroup-path instead of target-id",
+			args: []string{"--cgroup-path", "kubepods/burstable/pod-abc/container123", "--", "/stress-ng", "--cpu", "1"},
+			want: config{
+				cgroupPath:  "kubepods/burstable/pod-abc/container123",
+				driver:      driverAuto,
+				commandArgs: []string{"/stress-ng", "--cpu", "1"},
+			},
+		},
+		{
+			name:    "cgroup-path and target-id mutually exclusive",
+			args:    []string{"--cgroup-path", "kubepods/foo", "--target-id", "aabbccddeeff", "--", "/stress-ng"},
+			wantErr: "--cgroup-path and --target-id are mutually exclusive",
+		},
+		{
+			name:    "cgroup-path without value",
+			args:    []string{"--cgroup-path", "--", "/stress-ng"},
+			wantErr: "--cgroup-path requires a value",
+		},
+		{
+			name:    "cgroup-path with path traversal",
+			args:    []string{"--cgroup-path", "kubepods/../../etc", "--", "/stress-ng"},
+			wantErr: "must not contain '..'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseArgs(tt.args)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.targetID != tt.want.targetID {
+				t.Errorf("targetID = %q, want %q", got.targetID, tt.want.targetID)
+			}
+			if got.cgroupPath != tt.want.cgroupPath {
+				t.Errorf("cgroupPath = %q, want %q", got.cgroupPath, tt.want.cgroupPath)
+			}
+			if got.driver != tt.want.driver {
+				t.Errorf("driver = %q, want %q", got.driver, tt.want.driver)
+			}
+			if len(got.commandArgs) != len(tt.want.commandArgs) {
+				t.Fatalf("commandArgs len = %d, want %d", len(got.commandArgs), len(tt.want.commandArgs))
+			}
+			for i := range got.commandArgs {
+				if got.commandArgs[i] != tt.want.commandArgs[i] {
+					t.Errorf("commandArgs[%d] = %q, want %q", i, got.commandArgs[i], tt.want.commandArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCgroupProcsPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		targetID string
+		version  cgroupVersion
+		driver   cgroupDriver
+		want     []string
+	}{
+		{
+			name:     "v2 cgroupfs",
+			targetID: "abc123",
+			version:  cgroupV2,
+			driver:   driverCgroupfs,
+			want:     []string{"/test/cgroup/docker/abc123/cgroup.procs"},
+		},
+		{
+			name:     "v2 systemd",
+			targetID: "def456",
+			version:  cgroupV2,
+			driver:   driverSystemd,
+			want:     []string{"/test/cgroup/system.slice/docker-def456.scope/cgroup.procs"},
+		},
+		{
+			name:     "v1 cgroupfs",
+			targetID: "abc123",
+			version:  cgroupV1,
+			driver:   driverCgroupfs,
+			want: []string{
+				"/test/cgroup/cpu/docker/abc123/cgroup.procs",
+				"/test/cgroup/memory/docker/abc123/cgroup.procs",
+				"/test/cgroup/blkio/docker/abc123/cgroup.procs",
+				"/test/cgroup/cpuacct/docker/abc123/cgroup.procs",
+				"/test/cgroup/pids/docker/abc123/cgroup.procs",
+			},
+		},
+		{
+			name:     "v1 systemd",
+			targetID: "aabbccdd1122",
+			version:  cgroupV1,
+			driver:   driverSystemd,
+			want: []string{
+				"/test/cgroup/cpu/system.slice/docker-aabbccdd1122.scope/cgroup.procs",
+				"/test/cgroup/memory/system.slice/docker-aabbccdd1122.scope/cgroup.procs",
+				"/test/cgroup/blkio/system.slice/docker-aabbccdd1122.scope/cgroup.procs",
+				"/test/cgroup/cpuacct/system.slice/docker-aabbccdd1122.scope/cgroup.procs",
+				"/test/cgroup/pids/system.slice/docker-aabbccdd1122.scope/cgroup.procs",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origRoot := cgroupRoot
+			cgroupRoot = "/test/cgroup"
+			defer func() { cgroupRoot = origRoot }()
+
+			got := cgroupProcsPaths(tt.targetID, tt.version, tt.driver)
+			if len(got) != len(tt.want) {
+				t.Fatalf("cgroupProcsPaths() returned %d paths, want %d\ngot:  %v\nwant: %v", len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("cgroupProcsPaths()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCgroupProcsPathsFromBase(t *testing.T) {
+	origRoot := cgroupRoot
+	defer func() { cgroupRoot = origRoot }()
+	cgroupRoot = "/test/cgroup"
+
+	tests := []struct {
+		name     string
+		basePath string
+		version  cgroupVersion
+		want     []string
+	}{
+		{
+			name:     "v2 K8s path",
+			basePath: "kubepods/burstable/pod-abc123/deadbeef1234",
+			version:  cgroupV2,
+			want:     []string{"/test/cgroup/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs"},
+		},
+		{
+			name:     "v1 K8s path iterates controllers",
+			basePath: "kubepods/burstable/pod-abc123/deadbeef1234",
+			version:  cgroupV1,
+			want: []string{
+				"/test/cgroup/cpu/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs",
+				"/test/cgroup/memory/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs",
+				"/test/cgroup/blkio/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs",
+				"/test/cgroup/cpuacct/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs",
+				"/test/cgroup/pids/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs",
+			},
+		},
+		{
+			name:     "v2 simple Docker path",
+			basePath: "docker/abc123",
+			version:  cgroupV2,
+			want:     []string{"/test/cgroup/docker/abc123/cgroup.procs"},
+		},
+		{
+			name:     "v2 leading slash normalized",
+			basePath: "/kubepods/burstable/pod-abc123/deadbeef1234",
+			version:  cgroupV2,
+			want:     []string{"/test/cgroup/kubepods/burstable/pod-abc123/deadbeef1234/cgroup.procs"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cgroupProcsPathsFromBase(tt.basePath, tt.version)
+			if len(got) != len(tt.want) {
+				t.Fatalf("returned %d paths, want %d\ngot:  %v\nwant: %v", len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDetectCgroupVersion(t *testing.T) {
+	origRoot := cgroupRoot
+	defer func() { cgroupRoot = origRoot }()
+
+	t.Run("v2 when cgroup.controllers exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		// Create cgroup.controllers to simulate v2
+		if err := os.WriteFile(filepath.Join(tmpDir, "cgroup.controllers"), []byte("cpu memory"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := detectCgroupVersion(); got != cgroupV2 {
+			t.Errorf("detectCgroupVersion() = %v, want cgroupV2", got)
+		}
+	})
+
+	t.Run("v1 when cgroup.controllers absent", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if got := detectCgroupVersion(); got != cgroupV1 {
+			t.Errorf("detectCgroupVersion() = %v, want cgroupV1", got)
+		}
+	})
+}
+
+func TestDetectDriver(t *testing.T) {
+	origRoot := cgroupRoot
+	defer func() { cgroupRoot = origRoot }()
+
+	t.Run("v2 with docker dir returns cgroupfs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if err := os.MkdirAll(filepath.Join(tmpDir, "docker"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := detectDriver(cgroupV2); got != driverCgroupfs {
+			t.Errorf("detectDriver(v2) = %q, want cgroupfs", got)
+		}
+	})
+
+	t.Run("v2 with docker dir prefers cgroupfs over systemd", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		// Both exist (systemd host with Docker using cgroupfs driver)
+		if err := os.MkdirAll(filepath.Join(tmpDir, "docker"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(tmpDir, "system.slice"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := detectDriver(cgroupV2); got != driverCgroupfs {
+			t.Errorf("detectDriver(v2) = %q, want cgroupfs (docker dir should take priority)", got)
+		}
+	})
+
+	t.Run("v2 with only system.slice returns systemd", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if err := os.MkdirAll(filepath.Join(tmpDir, "system.slice"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := detectDriver(cgroupV2); got != driverSystemd {
+			t.Errorf("detectDriver(v2) = %q, want systemd", got)
+		}
+	})
+
+	t.Run("v2 with neither returns cgroupfs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if got := detectDriver(cgroupV2); got != driverCgroupfs {
+			t.Errorf("detectDriver(v2) = %q, want cgroupfs", got)
+		}
+	})
+
+	t.Run("v1 with cpu/docker returns cgroupfs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if err := os.MkdirAll(filepath.Join(tmpDir, "cpu", "docker"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := detectDriver(cgroupV1); got != driverCgroupfs {
+			t.Errorf("detectDriver(v1) = %q, want cgroupfs", got)
+		}
+	})
+
+	t.Run("v1 with only cpu/system.slice returns systemd", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if err := os.MkdirAll(filepath.Join(tmpDir, "cpu", "system.slice"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := detectDriver(cgroupV1); got != driverSystemd {
+			t.Errorf("detectDriver(v1) = %q, want systemd", got)
+		}
+	})
+
+	t.Run("v1 without either returns cgroupfs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+		if got := detectDriver(cgroupV1); got != driverCgroupfs {
+			t.Errorf("detectDriver(v1) = %q, want cgroupfs", got)
+		}
+	})
+}
+
+func TestWritePID(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "cgroup.procs")
+
+	// Pre-create the file (writePID uses O_WRONLY without O_CREATE, like real cgroup.procs)
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writePID(path, 12345); err != nil {
+		t.Fatalf("writePID() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if string(data) != "12345\n" {
+		t.Errorf("file content = %q, want %q", string(data), "12345\n")
+	}
+}
+
+func TestWritePID_ErrorOnMissingDir(t *testing.T) {
+	err := writePID("/nonexistent/dir/cgroup.procs", 1)
+	if err == nil {
+		t.Fatal("expected error for nonexistent directory, got nil")
+	}
+}
+
+func TestRun(t *testing.T) {
+	origRoot := cgroupRoot
+	origExec := execCommand
+	defer func() {
+		cgroupRoot = origRoot
+		execCommand = origExec
+	}()
+
+	t.Run("successful run with cgroupfs v2", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+
+		// Create v2 indicator
+		if err := os.WriteFile(filepath.Join(tmpDir, "cgroup.controllers"), []byte("cpu"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create the target cgroup directory and cgroup.procs file
+		targetDir := filepath.Join(tmpDir, "docker", "abc123")
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var execCalled bool
+		var execPath string
+		var execArgs []string
+		execCommand = func(argv0 string, argv []string, envv []string) error {
+			execCalled = true
+			execPath = argv0
+			execArgs = argv
+			return nil
+		}
+
+		cfg := config{
+			targetID:    "abc123",
+			driver:      driverAuto,
+			commandArgs: []string{"/stress-ng", "--cpu", "1"},
+		}
+
+		if err := run(cfg); err != nil {
+			t.Fatalf("run() error: %v", err)
+		}
+
+		if !execCalled {
+			t.Fatal("exec was not called")
+		}
+		if execPath != "/stress-ng" {
+			t.Errorf("exec path = %q, want /stress-ng", execPath)
+		}
+		if len(execArgs) != 3 || execArgs[0] != "/stress-ng" || execArgs[1] != "--cpu" || execArgs[2] != "1" {
+			t.Errorf("exec args = %v, want [/stress-ng --cpu 1]", execArgs)
+		}
+
+		// Verify PID was written
+		data, err := os.ReadFile(filepath.Join(targetDir, "cgroup.procs"))
+		if err != nil {
+			t.Fatalf("reading cgroup.procs: %v", err)
+		}
+		if len(data) == 0 {
+			t.Error("cgroup.procs is empty")
+		}
+	})
+
+	t.Run("successful run with cgroup-path v2", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+
+		// Create v2 indicator
+		if err := os.WriteFile(filepath.Join(tmpDir, "cgroup.controllers"), []byte("cpu"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create the K8s-style cgroup directory and cgroup.procs file
+		targetDir := filepath.Join(tmpDir, "kubepods", "burstable", "pod-abc", "deadbeef1234")
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var execCalled bool
+		execCommand = func(argv0 string, argv []string, _ []string) error {
+			execCalled = true
+			return nil
+		}
+
+		cfg := config{
+			cgroupPath:  "kubepods/burstable/pod-abc/deadbeef1234",
+			commandArgs: []string{"/stress-ng", "--cpu", "1"},
+		}
+
+		if err := run(cfg); err != nil {
+			t.Fatalf("run() error: %v", err)
+		}
+		if !execCalled {
+			t.Fatal("exec was not called")
+		}
+
+		data, err := os.ReadFile(filepath.Join(targetDir, "cgroup.procs"))
+		if err != nil {
+			t.Fatalf("reading cgroup.procs: %v", err)
+		}
+		if len(data) == 0 {
+			t.Error("cgroup.procs is empty")
+		}
+	})
+
+	t.Run("successful run with cgroup-path v1", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+
+		// v1: no cgroup.controllers file
+		// Create controller dirs with cgroup.procs
+		basePath := "kubepods/burstable/pod-abc/deadbeef1234"
+		for _, ctrl := range v1Controllers {
+			dir := filepath.Join(tmpDir, ctrl, basePath)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var execCalled bool
+		execCommand = func(string, []string, []string) error {
+			execCalled = true
+			return nil
+		}
+
+		cfg := config{
+			cgroupPath:  basePath,
+			commandArgs: []string{"/stress-ng"},
+		}
+
+		if err := run(cfg); err != nil {
+			t.Fatalf("run() error: %v", err)
+		}
+		if !execCalled {
+			t.Fatal("exec was not called")
+		}
+
+		// Verify PID was written to all controllers
+		for _, ctrl := range v1Controllers {
+			data, err := os.ReadFile(filepath.Join(tmpDir, ctrl, basePath, "cgroup.procs"))
+			if err != nil {
+				t.Fatalf("reading %s cgroup.procs: %v", ctrl, err)
+			}
+			if len(data) == 0 {
+				t.Errorf("%s cgroup.procs is empty", ctrl)
+			}
+		}
+	})
+
+	t.Run("write PID fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+
+		execCommand = func(string, []string, []string) error {
+			t.Fatal("exec should not be called on write failure")
+			return nil
+		}
+
+		cfg := config{
+			targetID:    "aabbccddeeff",
+			driver:      driverCgroupfs,
+			commandArgs: []string{"/stress-ng"},
+		}
+
+		err := run(cfg)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("exec failure propagated", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cgroupRoot = tmpDir
+
+		// Create v2 indicator so cgroupfs uses /docker/ path
+		if err := os.WriteFile(filepath.Join(tmpDir, "cgroup.controllers"), []byte("cpu"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create target cgroup directory and cgroup.procs file
+		targetDir := filepath.Join(tmpDir, "docker", "aabbccddee11")
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		execCommand = func(string, []string, []string) error {
+			return errors.New("exec failed")
+		}
+
+		cfg := config{
+			targetID:    "aabbccddee11",
+			driver:      driverCgroupfs,
+			commandArgs: []string{"/stress-ng"},
+		}
+
+		err := run(cfg)
+		if err == nil || !strings.Contains(err.Error(), "exec failed") {
+			t.Fatalf("expected exec error, got: %v", err)
+		}
+	})
+}

--- a/cmd/cg-inject/main_test.go
+++ b/cmd/cg-inject/main_test.go
@@ -448,7 +448,7 @@ func TestRun(t *testing.T) {
 		var execCalled bool
 		var execPath string
 		var execArgs []string
-		execCommand = func(argv0 string, argv []string, envv []string) error {
+		execCommand = func(argv0 string, argv []string, _ []string) error {
 			execCalled = true
 			execPath = argv0
 			execArgs = argv
@@ -504,7 +504,7 @@ func TestRun(t *testing.T) {
 		}
 
 		var execCalled bool
-		execCommand = func(argv0 string, argv []string, _ []string) error {
+		execCommand = func(_ string, _ []string, _ []string) error {
 			execCalled = true
 			return nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/alexei-led/stress-ng
+
+go 1.23

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -1,24 +1,63 @@
 #!/usr/bin/env bash
-# Integration tests for stress-ng Docker image
+# Integration tests for the stress-ng Docker image.
+# Tests both /stress-ng (default entrypoint) and /cg-inject (Pumba inject-cgroup helper).
 set -euo pipefail
 
 IMAGE="${TEST_IMAGE:?TEST_IMAGE must be set}"
 
 echo "=== Testing image: ${IMAGE} ==="
+PASS=0
+FAIL=0
 
-# Test 1: Version output
-echo "[1/3] Checking --version..."
-docker run --rm "${IMAGE}" --version
-echo "PASS"
+run_test() {
+  local name="$1"; shift
+  echo ""
+  echo "── ${name}"
+  if "$@"; then
+    echo "   PASS"
+    ((PASS++)) || true
+  else
+    echo "   FAIL (exit $?)"
+    ((FAIL++)) || true
+  fi
+}
 
-# Test 2: CPU stress (2 workers, 5 seconds)
-echo "[2/3] Running CPU stress test (5s)..."
-docker run --rm "${IMAGE}" --cpu 2 --timeout 5s --metrics-brief
-echo "PASS"
+# ── stress-ng tests ───────────────────────────────────────────────────────────
 
-# Test 3: VM stress (1 worker, 32MB, 5 seconds)
-echo "[3/3] Running VM stress test (5s)..."
-docker run --rm "${IMAGE}" --vm 1 --vm-bytes 32M --timeout 5s --metrics-brief
-echo "PASS"
+run_test "[stress-ng] version output" \
+  docker run --rm "${IMAGE}" --version
 
-echo "=== All tests passed ==="
+run_test "[stress-ng] CPU stress (2 workers, 5s)" \
+  docker run --rm "${IMAGE}" --cpu 2 --timeout 5s --metrics-brief
+
+run_test "[stress-ng] VM stress (1 worker, 32MB, 5s)" \
+  docker run --rm "${IMAGE}" --vm 1 --vm-bytes 32M --timeout 5s --metrics-brief
+
+# ── cg-inject tests ───────────────────────────────────────────────────────────
+# These tests verify the cg-inject binary is present and behaves correctly
+# for arg parsing. Actual cgroup injection requires kernel privileges and is
+# tested end-to-end by Pumba's integration test suite.
+
+run_test "[cg-inject] binary exists and shows usage on missing args" bash -c \
+  "docker run --rm --entrypoint /cg-inject '${IMAGE}' 2>&1 | grep -q 'missing.*separator'"
+
+run_test "[cg-inject] rejects unknown flag" bash -c \
+  "docker run --rm --entrypoint /cg-inject '${IMAGE}' --bad-flag -- /stress-ng 2>&1 | grep -q 'unknown flag'"
+
+run_test "[cg-inject] rejects invalid container ID" bash -c \
+  "docker run --rm --entrypoint /cg-inject '${IMAGE}' --target-id not-hex -- /stress-ng 2>&1 | grep -q 'invalid container ID'"
+
+run_test "[cg-inject] rejects path traversal in --cgroup-path" bash -c \
+  "docker run --rm --entrypoint /cg-inject '${IMAGE}' --cgroup-path 'foo/../../etc' -- /stress-ng 2>&1 | grep -q 'must not contain'"
+
+run_test "[cg-inject] rejects mutually exclusive flags" bash -c \
+  "docker run --rm --entrypoint /cg-inject '${IMAGE}' --cgroup-path foo --target-id aabbccddeeff -- /stress-ng 2>&1 | grep -q 'mutually exclusive'"
+
+echo ""
+echo "═══════════════════════════════════════"
+echo " Results: ${PASS} passed, ${FAIL} failed"
+echo "═══════════════════════════════════════"
+
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds the `cg-inject` helper binary to this image, resolving the architectural issue from issue #4.

### Problem

Pumba v0.12.1+ added `--inject-cgroup` mode, which requires the stress-ng image to have a `/cg-inject` entrypoint. The code lived in the Pumba repo, but including it via `FROM ghcr.io/alexei-led/pumba:latest` would create a **circular Docker image dependency** (Pumba depends on this image at runtime; this image can't depend on Pumba at build time).

### Solution

Move `cg-inject` source here and build it in a Go builder stage inside the Dockerfile.

```
Dependency graph (after this PR):
  Pumba ──(runtime dep)──► stress-ng image
                                ▲
                           builds cg-inject internally
```

### Changes

| File | Change |
|------|--------|
| `cmd/cg-inject/main.go` | Source moved from `alexei-led/pumba` — pure stdlib, zero deps |
| `cmd/cg-inject/main_test.go` | Full unit test suite (all tests pass) |
| `go.mod` | Go module declaration |
| `Dockerfile` | Two-stage: Go builder (cg-inject) → scratch (stress-ng + cg-inject) |
| `.golangci.yaml` | golangci-lint v2 config |
| `Makefile` | `test`, `lint`, `build`, `fmt`, `clean` targets |
| `.gitignore` | Ignores root binaries and `coverage.out` |
| `.github/workflows/ci.yaml` | Adds `go-lint` and `go-test` jobs |
| `.github/workflows/build-release.yaml` | Runs unit tests on each arch runner before building |
| `tests/test-docker.sh` | Adds 5 cg-inject behaviour tests (arg parsing, error cases) |

### Image contents (after)

| Binary | Purpose |
|--------|---------|
| `/stress-ng` | Default entrypoint — the stress-ng tool |
| `/cg-inject` | Pumba `--inject-cgroup` helper — joins target cgroup then exec's stress-ng |

### Testing

- Unit tests: `go test -race ./cmd/cg-inject/` — all pass ✅
- Integration tests: 3 stress-ng tests + 5 cg-inject behaviour tests

Closes #4

---
*🤖 Automated response by Marvin • [alexei-led](https://github.com/alexei-led)*